### PR TITLE
LOG4J-2518 LOG4J2-2433 Coroutines Support

### DIFF
--- a/log4j-api-kotlin/pom.xml
+++ b/log4j-api-kotlin/pom.xml
@@ -50,6 +50,11 @@
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-coroutines-jdk8</artifactId>
+      <version>${kotlinx.coroutines.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <type>test-jar</type>

--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/KotlinLogger.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/KotlinLogger.kt
@@ -117,19 +117,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, level, null, msg, t)
   }
 
-  fun log(level: Level, supplier: () -> Any?) {
+  inline fun log(level: Level, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, level, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun log(level: Level, t: Throwable, supplier: () -> Any?) {
+  inline fun log(level: Level, t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, level, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun log(level: Level, marker: Marker, supplier: () -> Any?) {
+  inline fun log(level: Level, marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, level, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun log(level: Level, marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun log(level: Level, marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, level, marker, supplier.asLog4jSupplier(), t)
   }
 
@@ -181,19 +181,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, Level.TRACE, null, msg, t)
   }
 
-  fun trace(supplier: () -> Any?) {
+  inline fun trace(supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.TRACE, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun trace(t: Throwable, supplier: () -> Any?) {
+  inline fun trace(t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.TRACE, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun trace(marker: Marker, supplier: () -> Any?) {
+  inline fun trace(marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.TRACE, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun trace(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun trace(marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.TRACE, marker, supplier.asLog4jSupplier(), t)
   }
 
@@ -203,11 +203,12 @@ class KotlinLogger(val delegate: ExtendedLogger) {
   }
 
   // TODO entry with fqcn is not part of the ExtendedLogger interface, location-awareness will be broken
-  fun traceEntry(supplier: () -> CharSequence): EntryMessage? {
+  inline fun traceEntry(supplier: () -> CharSequence): EntryMessage? {
     return if(delegate.isTraceEnabled) delegate.traceEntry(SimpleMessage(supplier())) else null
   }
 
-  fun traceEntry(vararg paramSuppliers: () -> Any?): EntryMessage {
+  @Suppress("NOTHING_TO_INLINE")
+  inline fun traceEntry(vararg paramSuppliers: () -> Any?): EntryMessage {
     return delegate.traceEntry(*paramSuppliers.asLog4jSuppliers())
   }
 
@@ -220,12 +221,12 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     return delegate.traceEntry(message)
   }
 
-  fun <R : Any?> runInTrace(block: () -> R): R {
+  inline fun <R : Any?> runInTrace(block: () -> R): R {
     return runInTrace(delegate.traceEntry(), block)
   }
 
   // TODO exit and catching with fqcn is not part of the ExtendedLogger interface, location-awareness will be broken
-  fun <R : Any?> runInTrace(entryMessage: EntryMessage, block: () -> R): R {
+  inline fun <R : Any?> runInTrace(entryMessage: EntryMessage, block: () -> R): R {
     return try {
       val result = block()
       when(result) {
@@ -287,19 +288,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, Level.DEBUG, null, msg, t)
   }
 
-  fun debug(supplier: () -> Any?) {
+  inline fun debug(supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.DEBUG, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun debug(t: Throwable, supplier: () -> Any?) {
+  inline fun debug(t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.DEBUG, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun debug(marker: Marker, supplier: () -> Any?) {
+  inline fun debug(marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.DEBUG, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun debug(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun debug(marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.DEBUG, marker, supplier.asLog4jSupplier(), t)
   }
 
@@ -351,19 +352,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, Level.INFO, null, msg, t)
   }
 
-  fun info(supplier: () -> Any?) {
+  inline fun info(supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.INFO, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun info(t: Throwable, supplier: () -> Any?) {
+  inline fun info(t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.INFO, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun info(marker: Marker, supplier: () -> Any?) {
+  inline fun info(marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.INFO, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun info(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun info(marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.INFO, marker, supplier.asLog4jSupplier(), t)
   }
 
@@ -415,19 +416,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, Level.WARN, null, msg, t)
   }
 
-  fun warn(supplier: () -> Any?) {
+  inline fun warn(supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.WARN, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun warn(t: Throwable, supplier: () -> Any?) {
+  inline fun warn(t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.WARN, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun warn(marker: Marker, supplier: () -> Any?) {
+  inline fun warn(marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.WARN, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun warn(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun warn(marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.WARN, marker, supplier.asLog4jSupplier(), t)
   }
 
@@ -479,19 +480,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, Level.ERROR, null, msg, t)
   }
 
-  fun error(supplier: () -> Any?) {
+  inline fun error(supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.ERROR, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun error(t: Throwable, supplier: () -> Any?) {
+  inline fun error(t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.ERROR, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun error(marker: Marker, supplier: () -> Any?) {
+  inline fun error(marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.ERROR, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun error(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun error(marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.ERROR, marker, supplier.asLog4jSupplier(), t)
   }
 
@@ -543,19 +544,19 @@ class KotlinLogger(val delegate: ExtendedLogger) {
     delegate.logIfEnabled(FQCN, Level.FATAL, null, msg, t)
   }
 
-  fun fatal(supplier: () -> Any?) {
+  inline fun fatal(supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.FATAL, null, supplier.asLog4jSupplier(), null)
   }
 
-  fun fatal(t: Throwable, supplier: () -> Any?) {
+  inline fun fatal(t: Throwable, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.FATAL, null, supplier.asLog4jSupplier(), t)
   }
 
-  fun fatal(marker: Marker, supplier: () -> Any?) {
+  inline fun fatal(marker: Marker, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.FATAL, marker, supplier.asLog4jSupplier(), null)
   }
 
-  fun fatal(marker: Marker, t: Throwable?, supplier: () -> Any?) {
+  inline fun fatal(marker: Marker, t: Throwable?, supplier: () -> Any?) {
     delegate.logIfEnabled(FQCN, Level.FATAL, marker, supplier.asLog4jSupplier(), t)
   }
 

--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/Suppliers.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/Suppliers.kt
@@ -14,10 +14,12 @@
  * See the license for the specific language governing permissions and
  * limitations under the license.
  */
+@file:Suppress("NOTHING_TO_INLINE")
+
 package org.apache.logging.log4j.kotlin
 
 import org.apache.logging.log4j.util.Supplier
 
-fun <T: Any?> (() -> T).asLog4jSupplier(): Supplier<T> = Supplier { invoke() }
+inline fun <T: Any?> (() -> T).asLog4jSupplier(): Supplier<T> = Supplier { invoke() }
 
-fun <T: Any?> (Array<out () -> T>).asLog4jSuppliers(): Array<Supplier<T>> = map { it.asLog4jSupplier() }.toTypedArray()
+inline fun <T: Any?> (Array<out () -> T>).asLog4jSuppliers(): Array<Supplier<T>> = map { it.asLog4jSupplier() }.toTypedArray()

--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/ThreadContextContext.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/ThreadContextContext.kt
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.kotlin
+
+import kotlinx.coroutines.ThreadContextElement
+import org.apache.logging.log4j.ThreadContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+
+/**
+ * The value of [ThreadContext] map and stack.
+ * See [ThreadContext.getImmutableContext] and [ThreadContext.getImmutableStack].
+ */
+public data class ThreadContextContents(
+  val map: Map<String, String>?,
+  val stack: Collection<String>?
+)
+
+/**
+ * Log4j2 [ThreadContext] element for [CoroutineContext]. The name is a bit confusing
+ * because this is the Kotlin coroutines "Context" for the Log4j2 "ThreadContext",
+ * therefore [ThreadContextContext].
+ *
+ * This is based on the SLF4J MDCContext maintained by Jetbrains:
+ * https://github.com/Kotlin/kotlinx.coroutines/blob/master/integration/kotlinx-coroutines-slf4j/src/MDCContext.kt
+ *
+ * Example:
+ *
+ * ```
+ * ThreadContext.put("kotlin", "rocks") // Put a value into the Thread context
+ *
+ * launch(ThreadContextContext()) {
+ *     logger.info { "..." }   // The Thread context contains the mapping here
+ * }
+ * ```
+ *
+ * Note, that you cannot update Thread context from inside of the coroutine simply
+ * using [ThreadContext.put]. These updates are going to be lost on the next suspension and
+ * reinstalled to the Thread context that was captured or explicitly specified in
+ * [contextMap] when this object was created on the next resumption.
+ * Use `withContext(ThreadContext()) { ... }` to capture updated map of Thread keys and values
+ * for the specified block of code.
+ *
+ * @param contextMap the value of [Thread] context map.
+ * Default value is the copy of the current thread's context map that is acquired via
+ * [ThreadContext.getContext].
+ */
+public class ThreadContextContext(
+  /**
+   * The value of [Thread] context map.
+   */
+  public val contextContents: ThreadContextContents = ThreadContextContents(ThreadContext.getImmutableContext(), ThreadContext.getImmutableStack())
+) : ThreadContextElement<ThreadContextContents>, AbstractCoroutineContextElement(Key) {
+  /**
+   * Key of [ThreadContext] in [CoroutineContext].
+   */
+  companion object Key : CoroutineContext.Key<ThreadContextContext>
+
+  /** @suppress */
+  override fun updateThreadContext(context: CoroutineContext): ThreadContextContents {
+    val oldState = ThreadContextContents(ThreadContext.getImmutableContext(), ThreadContext.getImmutableStack())
+    setCurrent(contextContents)
+    return oldState
+  }
+
+  /** @suppress */
+  override fun restoreThreadContext(context: CoroutineContext, oldState: ThreadContextContents) {
+    setCurrent(oldState)
+  }
+
+  private fun setCurrent(contextContents: ThreadContextContents) {
+    if (contextContents.map == null) {
+      ThreadContext.clearMap()
+    } else {
+      ThreadContext.putAll(contextContents.map)
+    }
+    if (contextContents.stack == null) {
+      ThreadContext.clearStack()
+    } else {
+      ThreadContext.setStack(contextContents.stack)
+    }
+  }
+}

--- a/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/LoggerCoroutinesTest.kt
+++ b/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/LoggerCoroutinesTest.kt
@@ -1,0 +1,19 @@
+package org.apache.logging.log4j.kotlin
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.apache.logging.log4j.junit.LoggerContextRule
+import org.junit.Rule
+import org.junit.Test
+
+class LoggerCoroutinesTest {
+  @Rule @JvmField var init = LoggerContextRule("InfoLogger.xml")
+
+  @Test
+  fun `Can use suppliers with suspend functions`() = runBlocking {
+    logger().error {
+      // expensive operation with suspend, because the lambda is inlined we can call this
+      delay(5)
+    }
+  }
+}

--- a/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/ThreadContextTest.kt
+++ b/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/ThreadContextTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.kotlin
+
+import kotlinx.coroutines.*
+import org.apache.logging.log4j.ThreadContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.assertEquals
+
+class ThreadContextTest {
+  @Before
+  fun setUp() {
+    ThreadContext.clearAll()
+  }
+
+  @After
+  fun tearDown() {
+    ThreadContext.clearAll()
+  }
+
+  @Test
+  fun `Context is not passed by default between coroutines`() = runBlocking<Unit> {
+    ThreadContext.put("myKey", "myValue")
+    // Scoped launch with MDCContext element
+    GlobalScope.launch {
+      assertEquals(null, ThreadContext.get("myKey"))
+    }.join()
+  }
+
+  @Test
+  fun `Context can be passed between coroutines`() = runBlocking<Unit> {
+    ThreadContext.put("myKey", "myValue")
+    // Scoped launch with MDCContext element
+    GlobalScope.launch(ThreadContextContext()) {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+    }.join()
+  }
+
+  @Test
+  fun `Context inheritance`() = runBlocking<Unit> {
+    ThreadContext.put("myKey", "myValue")
+    // Scoped launch with MDCContext element
+    withContext(ThreadContextContext()) {
+      ThreadContext.put("myKey", "myValue2")
+      // Scoped launch with inherited MDContext element
+      launch(Dispatchers.Default) {
+        assertEquals("myValue", ThreadContext.get("myKey"))
+      }
+    }
+    assertEquals("myValue", ThreadContext.get("myKey"))
+  }
+
+  @Test
+  fun `Context passed while on main thread`() {
+    ThreadContext.put("myKey", "myValue")
+    // No MDCContext element
+    runBlocking {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+    }
+  }
+
+  @Test
+  fun `Context can be passed while on main thread`() {
+    ThreadContext.put("myKey", "myValue")
+    runBlocking(ThreadContextContext()) {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+    }
+  }
+
+  @Test
+  fun `Context may be empty`() {
+    runBlocking(ThreadContextContext()) {
+      assertEquals(null, ThreadContext.get("myKey"))
+    }
+  }
+
+  @Test
+  fun `Context with context`() = runBlocking {
+    ThreadContext.put("myKey", "myValue")
+    val mainDispatcher = coroutineContext[ContinuationInterceptor]!!
+    withContext(Dispatchers.Default + ThreadContextContext()) {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+      withContext(mainDispatcher) {
+        assertEquals("myValue", ThreadContext.get("myKey"))
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
     <jxr.plugin.version>2.5</jxr.plugin.version>
     <kotlin.version>1.3.10</kotlin.version>
+    <kotlinx.coroutines.version>1.0.1</kotlinx.coroutines.version>
     <log4j.version>2.11.0</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
     <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
     <jxr.plugin.version>2.5</jxr.plugin.version>
-    <kotlin.version>1.3.0</kotlin.version>
+    <kotlin.version>1.3.10</kotlin.version>
     <log4j.version>2.11.0</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>


### PR DESCRIPTION
Add support for coroutines by fixing [LOG4J-2518](https://issues.apache.org/jira/browse/LOG4J2-2518) and [LOG4J2-2433](https://issues.apache.org/jira/browse/LOG4J2-2433).

Suspend functions inside lambda functions are supported by making the lambdas inline, and ThreadContext support is added to integrate the thread-local ThreadContext with coroutines context.

@jvz Can you take a look please?