### PR TITLE
LOG4J2-2433 Coroutines Support

### DIFF
--- a/log4j-api-kotlin-sample/pom.xml
+++ b/log4j-api-kotlin-sample/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api-kotlin-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>log4j-api-kotlin-sample</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Kotlin API Samples</name>
   <description>Sample usage of the Log4j Kotlin API</description>

--- a/log4j-api-kotlin-sample/pom.xml
+++ b/log4j-api-kotlin-sample/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api-kotlin-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>log4j-api-kotlin-sample</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Kotlin API Samples</name>
   <description>Sample usage of the Log4j Kotlin API</description>

--- a/log4j-api-kotlin/pom.xml
+++ b/log4j-api-kotlin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api-kotlin-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>log4j-api-kotlin</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Kotlin API</name>
   <description>Kotlin wrapper for Log4j API</description>

--- a/log4j-api-kotlin/pom.xml
+++ b/log4j-api-kotlin/pom.xml
@@ -50,6 +50,11 @@
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-coroutines-jdk8</artifactId>
+      <version>${kotlinx.coroutines.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <type>test-jar</type>

--- a/log4j-api-kotlin/pom.xml
+++ b/log4j-api-kotlin/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>org.apache.logging.log4j</groupId>
     <artifactId>log4j-api-kotlin-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
   <artifactId>log4j-api-kotlin</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Apache Log4j Kotlin API</name>
   <description>Kotlin wrapper for Log4j API</description>

--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/CoroutineThreadContext.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/CoroutineThreadContext.kt
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.kotlin
+
+import kotlinx.coroutines.ThreadContextElement
+import org.apache.logging.log4j.ThreadContext
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * The value of [ThreadContext] map and stack.
+ * See [ThreadContext.getImmutableContext] and [ThreadContext.getImmutableStack].
+ */
+data class ThreadContextData(
+  val map: Map<String, String>?,
+  val stack: Collection<String>?
+)
+
+/**
+ * Log4j2 [ThreadContext] element for [CoroutineContext].
+ *
+ * This is based on the SLF4J MDCContext maintained by Jetbrains:
+ * https://github.com/Kotlin/kotlinx.coroutines/blob/master/integration/kotlinx-coroutines-slf4j/src/MDCContext.kt
+ *
+ * Example:
+ *
+ * ```
+ * ThreadContext.put("kotlin", "rocks") // Put a value into the Thread context
+ *
+ * launch(CoroutineThreadContext()) {
+ *     logger.info { "..." }   // The Thread context contains the mapping here
+ * }
+ * ```
+ *
+ * Note, that you cannot update Thread context from inside of the coroutine simply
+ * using [ThreadContext.put]. These updates are going to be lost on the next suspension and
+ * reinstalled to the Thread context that was captured or explicitly specified in
+ * [contextMap] when this object was created on the next resumption.
+ * Use `withContext(ThreadContext()) { ... }` to capture updated map of Thread keys and values
+ * for the specified block of code.
+ *
+ * @param contextMap the value of [Thread] context map.
+ * Default value is the copy of the current thread's context map that is acquired via
+ * [ThreadContext.getContext].
+ */
+class CoroutineThreadContext(
+  /**
+   * The value of [Thread] context map.
+   */
+  val contextData: ThreadContextData = ThreadContextData(ThreadContext.getImmutableContext(), ThreadContext.getImmutableStack())
+) : ThreadContextElement<ThreadContextData>, AbstractCoroutineContextElement(Key) {
+  /**
+   * Key of [ThreadContext] in [CoroutineContext].
+   */
+  companion object Key : CoroutineContext.Key<CoroutineThreadContext>
+
+  /** @suppress */
+  override fun updateThreadContext(context: CoroutineContext): ThreadContextData {
+    val oldState = ThreadContextData(ThreadContext.getImmutableContext(), ThreadContext.getImmutableStack())
+    setCurrent(contextData)
+    return oldState
+  }
+
+  /** @suppress */
+  override fun restoreThreadContext(context: CoroutineContext, oldState: ThreadContextData) {
+    setCurrent(oldState)
+  }
+
+  private fun setCurrent(contextData: ThreadContextData) {
+    if (contextData.map == null) {
+      ThreadContext.clearMap()
+    } else {
+      ThreadContext.putAll(contextData.map)
+    }
+    if (contextData.stack == null) {
+      ThreadContext.clearStack()
+    } else {
+      ThreadContext.setStack(contextData.stack)
+    }
+  }
+}

--- a/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/ThreadContextTest.kt
+++ b/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/ThreadContextTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.kotlin
+
+import kotlinx.coroutines.*
+import org.apache.logging.log4j.ThreadContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.assertEquals
+
+class ThreadContextTest {
+  @Before
+  fun setUp() {
+    ThreadContext.clearAll()
+  }
+
+  @After
+  fun tearDown() {
+    ThreadContext.clearAll()
+  }
+
+  @Test
+  fun `Context is not passed by default between coroutines`() = runBlocking<Unit> {
+    ThreadContext.put("myKey", "myValue")
+    // Scoped launch with MDCContext element
+    GlobalScope.launch {
+      assertEquals(null, ThreadContext.get("myKey"))
+    }.join()
+  }
+
+  @Test
+  fun `Context can be passed between coroutines`() = runBlocking<Unit> {
+    ThreadContext.put("myKey", "myValue")
+    // Scoped launch with MDCContext element
+    GlobalScope.launch(CoroutineThreadContext()) {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+    }.join()
+  }
+
+  @Test
+  fun `Context inheritance`() = runBlocking<Unit> {
+    ThreadContext.put("myKey", "myValue")
+    // Scoped launch with MDCContext element
+    withContext(CoroutineThreadContext()) {
+      ThreadContext.put("myKey", "myValue2")
+      // Scoped launch with inherited MDContext element
+      launch(Dispatchers.Default) {
+        assertEquals("myValue", ThreadContext.get("myKey"))
+      }
+    }
+    assertEquals("myValue", ThreadContext.get("myKey"))
+  }
+
+  @Test
+  fun `Context passed while on main thread`() {
+    ThreadContext.put("myKey", "myValue")
+    // No MDCContext element
+    runBlocking {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+    }
+  }
+
+  @Test
+  fun `Context can be passed while on main thread`() {
+    ThreadContext.put("myKey", "myValue")
+    runBlocking(CoroutineThreadContext()) {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+    }
+  }
+
+  @Test
+  fun `Context may be empty`() {
+    runBlocking(CoroutineThreadContext()) {
+      assertEquals(null, ThreadContext.get("myKey"))
+    }
+  }
+
+  @Test
+  fun `Context with context`() = runBlocking {
+    ThreadContext.put("myKey", "myValue")
+    val mainDispatcher = coroutineContext[ContinuationInterceptor]!!
+    withContext(Dispatchers.Default + CoroutineThreadContext()) {
+      assertEquals("myValue", ThreadContext.get("myKey"))
+      withContext(mainDispatcher) {
+        assertEquals("myValue", ThreadContext.get("myKey"))
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.apache.logging.log4j</groupId>
   <artifactId>log4j-api-kotlin-parent</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Log4j Kotlin API Parent</name>
   <description>Apache Log4j Kotlin API parent project</description>
@@ -36,7 +36,7 @@
     <connection>scm:git:http://git-wip-us.apache.org/repos/asf/logging-log4j-kotlin.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/logging-log4j-kotlin.git</developerConnection>
     <url>https://git-wip-us.apache.org/repos/asf?p=logging-log4j-kotlin.git;a=summary</url>
-    <tag>log4j-api-kotlin-1.0.0-rc3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <groupId>org.apache.logging.log4j</groupId>
   <artifactId>log4j-api-kotlin-parent</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
   <name>Apache Log4j Kotlin API Parent</name>
   <description>Apache Log4j Kotlin API parent project</description>
@@ -36,7 +36,7 @@
     <connection>scm:git:http://git-wip-us.apache.org/repos/asf/logging-log4j-kotlin.git</connection>
     <developerConnection>scm:git:https://git-wip-us.apache.org/repos/asf/logging-log4j-kotlin.git</developerConnection>
     <url>https://git-wip-us.apache.org/repos/asf?p=logging-log4j-kotlin.git;a=summary</url>
-    <tag>HEAD</tag>
+    <tag>log4j-api-kotlin-1.0.0-rc3</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
     <jxr.plugin.version>2.5</jxr.plugin.version>
     <kotlin.version>1.3.72</kotlin.version>
+    <kotlinx.coroutines.version>1.3.6</kotlinx.coroutines.version>
     <log4j.version>2.13.2</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>


### PR DESCRIPTION
Add support for coroutines by fixing LOG4J2-2433.

ThreadContext support is added to integrate the thread-local ThreadContext with coroutines context. Suspend functions inside lambda functions are not yet supported, because making the calls inline breaks caller location information. See discussion in https://github.com/apache/logging-log4j-kotlin/pull/7.

@jvz Can you take a look please?