### PR TITLE
Upgrade Kotlin to v1.4

### DIFF
--- a/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/LoggerTest.kt
+++ b/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/LoggerTest.kt
@@ -173,7 +173,8 @@ class LoggerTest {
   fun `Run in trace with result`() {
     var count = 0
     val f = withLevelFixture(Level.INFO, true) {
-      it.runInTrace(entryMsg) {
+      @SuppressWarnings("unused")
+      val mustBeHere = it.runInTrace(entryMsg) {
         ++count
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
     <javadoc.plugin.version>2.10.3</javadoc.plugin.version>
     <jxr.plugin.version>2.5</jxr.plugin.version>
-    <kotlin.version>1.3.72</kotlin.version>
+    <kotlin.version>1.4.21</kotlin.version>
     <kotlinx.coroutines.version>1.3.6</kotlinx.coroutines.version>
     <log4j.version>2.13.2</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>


### PR DESCRIPTION
I am using this library in my application, but it prevents me from upgrading to Kotlin v1.4 since this library includes Kotlin v1.3.72. I can force my application to use Kotlin stdlib 1.3, but then some of the point of upgrading will be gone.

This PR is not merge ready, since it may break all Kotlin v1.3 projects (not verified/checked), but it is not possible to create an issue, so this PR will serve as a placeholder for this issue I guess?!