### PR TITLE
Add caching for logger lookups via interface mixin

### DIFF
--- a/log4j-api-kotlin-benchmark/src/main/kotlin/org/apache/logging/log4j/kotlin/benchmark/LoggingBenchmark.kt
+++ b/log4j-api-kotlin-benchmark/src/main/kotlin/org/apache/logging/log4j/kotlin/benchmark/LoggingBenchmark.kt
@@ -18,9 +18,9 @@ package org.apache.logging.log4j.kotlin.benchmark
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import org.apache.logging.log4j.kotlin.Logging
 import org.apache.logging.log4j.kotlin.contextName
 import org.apache.logging.log4j.kotlin.logger
-//import org.apache.logging.log4j.kotlin.logger1
 import org.apache.logging.log4j.util.Supplier
 import org.openjdk.jmh.annotations.*
 import java.util.concurrent.TimeUnit
@@ -34,7 +34,7 @@ val LOGGER2 = logger(contextName {})
 @Warmup(iterations = 3, time = 5)
 @Measurement(iterations = 5, time = 1)
 open class LoggingBenchmark {
-  companion object {
+  companion object: Logging {
     @JvmStatic
     val LOGGER3 = logger()
     val LOGGER4: Logger = LogManager.getLogger()
@@ -78,5 +78,15 @@ open class LoggingBenchmark {
   @Benchmark
   fun companionObjectLog4jLoggerDirect() {
     LOGGER4.info("Test")
+  }
+
+  @Benchmark
+  fun companionObjectLookupInterfaceFunctional() {
+    logger.info {"Test" }
+  }
+
+  @Benchmark
+  fun companionObjectLookupInterfaceDirect() {
+    logger.info("Test")
   }
 }

--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/Logging.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/Logging.kt
@@ -41,9 +41,15 @@ package org.apache.logging.log4j.kotlin
  * }
  *
  * ```
+ *
+ * Note that this is significantly slower than creating a logger explicitly, as it requires a lookup of the
+ * logger on each call via the property getter, since we cannot store any state in an interface. We attempt to
+ * minimize the overhead of this by caching the loggers, but according to microbenchmarks, it is still about
+ * 3.5 times slower than creating a logger once and using it (about 4.2 nanoseconds per call instead of 1.2
+ * nanoseconds).
  */
 interface Logging {
   @Suppress("unused")
   val logger
-    get() = loggerOf(this.javaClass)
+    get() = cachedLoggerOf(this.javaClass)
 }

--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/LoggingFactory.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/LoggingFactory.kt
@@ -18,6 +18,8 @@ package org.apache.logging.log4j.kotlin
 
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.spi.ExtendedLogger
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentMap
 import kotlin.reflect.full.companionObject
 
 /**
@@ -67,6 +69,10 @@ fun loggerOf(ofClass: Class<*>): KotlinLogger {
   return KotlinLogger(loggerDelegateOf(ofClass))
 }
 
+fun cachedLoggerOf(ofClass: Class<*>): KotlinLogger {
+  return loggerCache.getOrPut(ofClass) { loggerOf(ofClass) }
+}
+
 // unwrap companion class to enclosing class given a Java Class
 private fun <T : Any> unwrapCompanionClass(ofClass: Class<T>): Class<*> {
   return if (ofClass.enclosingClass?.kotlin?.companionObject?.java == ofClass) {
@@ -75,3 +81,5 @@ private fun <T : Any> unwrapCompanionClass(ofClass: Class<T>): Class<*> {
     ofClass
   }
 }
+
+private val loggerCache = ConcurrentHashMap<Class<*>, KotlinLogger>()


### PR DESCRIPTION
I realized the mixin was super-slow because the property delegate creates a new logger every time it is used. See https://issues.apache.org/jira/browse/LOG4J2-3086.

The only workaround I could find was to use caching. However, I'm not super happy with the implementation here -- I don't like creating an unbounded cache like this. However, I don't see any easy workarounds. @jvz suggestions welcome.