### PR TITLE
LOG4J2-3218 update log4j2 dep: CVE-2021-44228

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <jxr.plugin.version>2.5</jxr.plugin.version>
     <kotlin.version>1.3.72</kotlin.version>
     <kotlinx.coroutines.version>1.3.6</kotlinx.coroutines.version>
-    <log4j.version>2.13.2</log4j.version>
+    <log4j.version>2.15.0</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>
     <site.plugin.version>3.4</site.plugin.version>


### PR DESCRIPTION
@jvz I'll merge this to master shortly, but given the visibility of this issue, but FYI. We should probably cut a new release sooner rather than later.