### PR TITLE
Refresh Log4j API Kotlin Documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+The Apache code of conduct page is [https://www.apache.org/foundation/policies/conduct.html](https://www.apache.org/foundation/policies/conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+<!---
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<!--
+This looks like it was generated, but it was actually modified from the
+CONTRIBUTING.md file from Apache Commons Lang.
+-->
+# Contributing to Apache Log4j 2
+
+You have found a bug or you have an idea for a cool new feature? Contributing code is a great way to give something back to
+the open source community. Before you dig right into the code there are a few guidelines that we need contributors to
+follow so that we can have a chance of keeping on top of things.
+
+## Getting Started
+
++ Make sure you have a [GitHub account](https://github.com/join).
++ If you're planning to implement a new feature it makes sense to discuss your changes on the [dev list](https://logging.apache.org/log4j/2.x/mail-lists.html) first. This way you can make sure you're not wasting your time on something that isn't considered to be in Apache Log4j's scope.
++ Submit a ticket for your issue, assuming one does not already exist.
+  + Clearly describe the issue including steps to reproduce when it is a bug.
+  + Make sure you fill in the earliest version that you know has the issue.
++ Fork the repository on GitHub.
+
+## Making Changes
+
++ Create a topic branch from where you want to base your work (this is usually the master branch).
++ Make commits of logical units.
++ Respect the original code style:
+  + Only use spaces for indentation.
+  + Create minimal diffs - disable on save actions like reformat source code or organize imports. If you feel the source code should be reformatted create a separate PR for this change.
+  + Check for unnecessary whitespace with git diff --check before committing.
++ Make sure your commit messages are in the proper format. Your commit message should contain the associated issue ID.
++ Make sure you have added the necessary tests for your changes.
++ Run all the tests with `mvn clean verify` to assure nothing else was accidentally broken.
+
+## Making Trivial Changes
+
+For changes of a trivial nature to comments and documentation, it is not always necessary to create a new ticket.
+In this case, it is appropriate to start the first line of a commit with '(doc)' instead of a ticket number.
+
+## Submitting Changes
+
++ Sign the [Contributor License Agreement][cla] if you haven't already.
++ Push your changes to a topic branch in your fork of the repository.
++ Submit a pull request to the repository in the apache organization.
++ Update your issue and include a link to the pull request in the ticket.
+
+## Additional Resources
+
++ [Project Guidelines](https://logging.apache.org/log4j/2.x/guidelines.html)
++ [Code Style Guide](https://logging.apache.org/log4j/2.x/javastyle.html)
++ [Apache Log4j 2 Issue Tracker](https://github.com/apache/logging-log4j2/issues)
++ [Contributor License Agreement][cla]
++ [General GitHub documentation](https://docs.github.com/)
++ [GitHub pull request documentation](https://docs.github.com/en/pull-requests)
+
+[cla]:https://www.apache.org/licenses/#clas

--- a/README.md
+++ b/README.md
@@ -17,22 +17,54 @@ judged to be non-trivial, you will be asked to actually signing a Contributor Li
 
 ## Usage
 
-Gradle users can add the following dependencies to their `build.gradle` file:
+Users should refer to [Maven, Ivy and Gradle Artifacts](https://logging.apache.org/log4j/kotlin/artifacts.html)
+on the Log4j website for instructions on how to include Log4j into their project using their chosen build tool.
 
-TODO
+Using the Kotlin API is as simple as mixing in the Logging interface to your class. Example:
 
-```groovy
-compile "org.apache.logging.log4j:log4j-api-kotlin:1.2.0"
-compile "org.apache.logging.log4j:log4j-api:2.17.0"
-compile "org.apache.logging.log4j:log4j-core:2.17.0"
+```kotlin
+import org.apache.logging.log4j.kotlin.Logging
+
+class MyClass: BaseClass, Logging {
+    fun doStuff() {
+        logger.info("Doing stuff")
+    }
+    
+    fun doStuffWithUser(user: User) {
+        logger.info { "Doing stuff with ${user.name}." }
+    }
+}
 ```
+
+The Logging interface can also be mixed into object declarations, including companions. This is generally preferable over the previous approach as there is a single logger created for every instance of the class.
+
+```kotlin
+import org.apache.logging.log4j.kotlin.Logging
+
+class MyClass: BaseClass {
+    companion object : Logging
+    
+    ...
+}
+```
+
+Alternatively, a more traditional style can be used to instantiate a logger instance:
+
+```kotlin
+import org.apache.logging.log4j.kotlin
+
+class MyClass: BaseClass {
+    val logger = logger()
+    
+    ...
+}
+```
+
+The function `logger()` is an extension function on the Any type (or more specifically, any type `T` that extends `Any`).
 
 ## Documentation
 
-[//]: # "The Log4j Kotlin API is documented [in the Log4j 2 manual](https://logging.apache.org/log4j/2.x/manual/kotlin-api.html)"
-[//]: # "and in the [KDocs](https://logging.apache.org/log4j/2.x/log4j-api-kotlin/kdocs/index.html#org.apache.logging.log4j.kotlin.package)."
-
-TODO
+The Kotlin's Log4j 2 User's Guide is available [here](https://logging.apache.org/log4j/kotlin/index.html).
 
 ## Requirements
 
@@ -57,7 +89,9 @@ Apache Log4j 2 is distributed under the [Apache License, version 2.0](http://www
 ## Download
 
 [How to download Log4j](http://logging.apache.org/log4j/2.x/download.html),
-and [how to use it from SBT, Maven, Ivy and Gradle](http://logging.apache.org/log4j/2.x/maven-artifacts.html).
+and [how to use it from Maven, Ivy and Gradle](http://logging.apache.org/log4j/2.x/maven-artifacts.html).
+You can access the latest development snapshot by using the Maven repository `https://repository.apache.org/snapshots`,
+see [Snapshot builds](https://logging.apache.org/log4j/2.x/maven-artifacts.html#Snapshot_builds).
 
 ## Issue Tracking
 
@@ -78,4 +112,5 @@ mvn install
 
 ## Contributing
 
-We love contributions! Take a look at [our contributing page](https://github.com/apache/logging-log4j-kotlin/blob/master/src/main/asciidoc/contributing.adoc).
+We love contributions!
+Take a look at [our contributing page](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ default logging implementation, but this is not strictly required (e.g., this AP
 or other Log4j 2 API provider implementations). Idiomatic Kotlin features are provided as an alternative to using
 the Log4j 2 Java API.
 
-[![Build Status](https://builds.apache.org/job/Log4jKotlin/job/master/badge/icon)](https://builds.apache.org/job/Log4jKotlin/job/master/)
+[![Build Status](https://ci-builds.apache.org/job/Logging/job/log4j-kotlin/job/master/lastBuild/badge/icon)](https://builds.apache.org/job/Logging/job/log4j-kotlin/job/master/)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ default logging implementation, but this is not strictly required (e.g., this AP
 or other Log4j 2 API provider implementations). Idiomatic Kotlin features are provided as an alternative to using
 the Log4j 2 Java API.
 
+[![Maven Central](https://img.shields.io/maven-central/v/org.apache.logging.log4j/log4j-api-kotlin.svg)](https://search.maven.org/artifact/org.apache.logging.log4j/log4j-api-kotlin)
 [![Build Status](https://ci-builds.apache.org/job/Logging/job/log4j-kotlin/job/master/lastBuild/badge/icon)](https://builds.apache.org/job/Logging/job/log4j-kotlin/job/master/)
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Apache Log4j 2 Kotlin API](http://logging.apache.org/log4j/2.x/)
+# [Apache Log4j 2 (Kotlin API)](http://logging.apache.org/log4j/2.x/)
 
 Log4j Kotlin API is a Kotlin logging facade based on Log4j 2. Log4j Kotlin API provides Log4j 2 as its
 default logging implementation, but this is not strictly required (e.g., this API can also be used with Logback
@@ -7,6 +7,13 @@ the Log4j 2 Java API.
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.logging.log4j/log4j-api-kotlin.svg)](https://search.maven.org/artifact/org.apache.logging.log4j/log4j-api-kotlin)
 [![Build Status](https://ci-builds.apache.org/job/Logging/job/log4j-kotlin/job/master/lastBuild/badge/icon)](https://builds.apache.org/job/Logging/job/log4j-kotlin/job/master/)
+
+## Pull Requests on Github
+
+By sending a pull request you grant the Apache Software Foundation sufficient rights to use and release the submitted
+work under the Apache license. You grant the same rights (copyright license, patent license, etc.) to the
+Apache Software Foundation as if you have signed a Contributor License Agreement. For contributions that are
+judged to be non-trivial, you will be asked to actually signing a Contributor License Agreement.
 
 ## Usage
 


### PR DESCRIPTION
Hello,

This is just a documentation refresh to match the latest `logging-log4j2` project conventions.

### Changelog
- Add missing CONTRIBUTING.md and CODE_OF_CONDUCT.md
- Update deadlinks, impove upon documentation
- Add a simple usage example to match logging-log4j2
- Add missing Github PR contributor guidelines to match logging-log4j2
- Add Maven Central Badge
- Fix Build status badge

Trivial changes - No functionality changes. Feel free to amend as needed. :)