### PR TITLE
Upgrade kotlin and log4j versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
     <findbugs.plugin.version>3.0.5</findbugs.plugin.version>
     <javadoc.plugin.version>3.4.0</javadoc.plugin.version>
     <jxr.plugin.version>2.5</jxr.plugin.version>
-    <kotlin.version>1.3.72</kotlin.version>
-    <kotlinx.coroutines.version>1.3.6</kotlinx.coroutines.version>
+    <kotlin.version>1.8.0</kotlin.version>
+    <kotlinx.coroutines.version>1.6.4</kotlinx.coroutines.version>
     <log4j.version>2.17.2</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <jxr.plugin.version>2.5</jxr.plugin.version>
     <kotlin.version>1.8.0</kotlin.version>
     <kotlinx.coroutines.version>1.6.4</kotlinx.coroutines.version>
-    <log4j.version>2.17.2</log4j.version>
+    <log4j.version>2.19.0</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>
     <site.plugin.version>3.11.0</site.plugin.version>


### PR DESCRIPTION
Hello,

It seems that the Log4j version of the Kotlin API is out of date.
On top of that, the Kotlin version hasn't been updated for the past 2 years.

I have did a code analysis scan and found no incompatibles, tests are passing, and everything seems to be working as excepted.  

### Reasons to upgrade to 1.8.0 that are relevant: 

- 1.8.0 - [Improved kotlin-reflect performance](https://kotlinlang.org/docs/whatsnew18.html#improved-kotlin-reflect-performance)
- 1.6.0 - [Further Improvements to type inference for recursive generic types](https://kotlinlang.org/docs/whatsnew16.html#improved-type-inference-for-recursive-generic-types)
- 1.5.30 - [Improvements to type inference for recursive generic types﻿](https://kotlinlang.org/docs/whatsnew1530.html#improvements-to-type-inference-for-recursive-generic-types)
- 1.5.0 - [Inline classes are released as Stable](https://kotlinlang.org/docs/whatsnew15.html#kotlin-jvm)

And lots of other performance improvements overall... 

### Changes

- Upgrade log4j to 2.19.0
- Upgrade Kotlin to 1.8.0
- kotlinx.coroutines to 1.6.4

Trivial changes - Feel free to amend as needed. :)