### PR TITLE
Upgrade log4j to 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <jxr.plugin.version>2.5</jxr.plugin.version>
     <kotlin.version>1.3.72</kotlin.version>
     <kotlinx.coroutines.version>1.3.6</kotlinx.coroutines.version>
-    <log4j.version>2.17.2</log4j.version>
+    <log4j.version>2.19.0</log4j.version>
     <pmd.plugin.version>3.8</pmd.plugin.version>
     <rat.plugin.version>0.12</rat.plugin.version>
     <site.plugin.version>3.11.0</site.plugin.version>


### PR DESCRIPTION
Hello,

It seems that the Log4j version is out of date.

Reason why to upgrade:
- 2.17.0 is considered a vulnerable version by Gradle Portal.

Changes
- Upgrade log4j to 2.19.0

Trivial changes - Feel free to amend as needed. :)