### PR TITLE
Kotlin 1.6.21, coroutines 1.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,8 @@
     <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <maven-shade-plugin.version>2.2</maven-shade-plugin.version>
+    <kotlin.version>1.6.21</kotlin.version>
+    <kotlinx.coroutines.version>1.6.4</kotlinx.coroutines.version>
 
   </properties>
 


### PR DESCRIPTION
Updating baseline to Kotlin 1.6.21 with coroutines 1.6.4.

FYI Mockito > 1.4.1 is compiled against JVM target 11 (not sure if intentional or not, but here is the issue: https://github.com/mockito/mockito-kotlin/issues/488). So I'm leaving the mockito version as-is for the moment.