### PR TITLE
Fix JPMS module descriptor

### DIFF
--- a/log4j-api-kotlin/pom.xml
+++ b/log4j-api-kotlin/pom.xml
@@ -31,6 +31,28 @@
   <name>Apache Log4j Kotlin API</name>
   <description>Kotlin wrapper for Log4j API</description>
 
+  <properties>
+    <!--
+      ~ OSGi and JPMS configuration
+      -->
+    <bnd-module-name>org.apache.logging.log4j.kotlin</bnd-module-name>
+    <bnd-extra-package-options>
+      <!-- Optional packages -->
+      kotlin.reflect.*;resolution:=optional,
+      kotlinx.coroutines.*;resolution:=optional
+    </bnd-extra-package-options>
+    <bnd-extra-module-options>
+      <!-- BND does not look in META-INF/versions/9 for a module descriptor -->
+      org.apache.logging.log4j;substitute="log4j-api",
+      kotlin.stdlib;substitute="kotlin-stdlib",
+      kotlin.reflect;substitute="kotlin-reflect",
+      <!-- Module name from version 1.7.x, version 1.6.x has no name -->
+      kotlinx.coroutines.core;substitute="kotlinx-coroutines-core-jvm";transitive=false,
+      <!-- Legacy library with no classes -->
+      kotlin-stdlib-common;ignore=true
+    </bnd-extra-module-options>
+  </properties>
+
   <dependencies>
 
     <dependency>

--- a/src/changelog/.1.x.x/JPMS.xml
+++ b/src/changelog/.1.x.x/JPMS.xml
@@ -3,5 +3,5 @@
        xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.1.xsd"
        type="added">
   <author id="github:vy"/>
-  <description format="asciidoc">Added JPMS support and used `org.apache.logging.log4j.api_kotlin` for the module name (identical to OSGi `Bundle-SymbolicName`) of the `log4j-api-kotlin` artifact</description>
+  <description format="asciidoc">Added JPMS support and used `org.apache.logging.log4j.kotlin` for the module name.</description>
 </entry>


### PR DESCRIPTION
The JPMS descriptor generated by BND has many issues, e.g. BND does not find JPMS descriptors inside `META-INF/versions/9`, hence most of the module names are wrong.

The descriptor generated by this PR is:
```
module org.apache.logging.log4j.kotlin@1.3.0.SNAPSHOT {
  requires java.base;
  requires static kotlin.reflect;
  requires transitive kotlin.stdlib;
  requires static kotlinx.coroutines.core;
  requires transitive org.apache.logging.log4j;
  exports org.apache.logging.log4j.kotlin;
}
```

Looking at the code, I am assuming that usage of `kotlin.reflect` and `kotlinx.coroutines.core` is optional.