### PR TITLE
Logging context convenience functions for coroutines

### DIFF
--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/CoroutineThreadContext.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/CoroutineThreadContext.kt
@@ -17,7 +17,9 @@
 package org.apache.logging.log4j.kotlin
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.ThreadContext
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
@@ -34,7 +36,12 @@ import kotlin.coroutines.CoroutineContext
 data class ThreadContextData(
   val map: Map<String, String>? = ContextMap.view,
   val stack: Collection<String>? = ContextStack.view
-)
+) {
+  operator fun plus(data: ThreadContextData) = ThreadContextData(
+    map = this.map.orEmpty() + data.map.orEmpty(),
+    stack = this.stack.orEmpty() + data.stack.orEmpty(),
+  )
+}
 
 /**
  * Log4j2 [ThreadContext] element for [CoroutineContext].
@@ -58,6 +65,9 @@ data class ThreadContextData(
  * [contextData] when this object was created on the next resumption.
  * Use `withContext(CoroutineThreadContext()) { ... }` to capture updated map of Thread keys and values
  * for the specified block of code.
+ *
+ * See [loggingContext] and [additionalLoggingContext] for convenience functions that make working with a
+ * [CoroutineThreadContext] simpler.
  *
  * @param contextData the value of [Thread] context map and context stack.
  * Default value is the copy of the current thread's context map that is acquired via
@@ -95,3 +105,73 @@ class CoroutineThreadContext(
     contextData.stack?.let { ContextStack.set(it) }
   }
 }
+
+/**
+ * Convenience function to obtain a [CoroutineThreadContext] with the given map and stack, which default
+ * to no context. Any existing logging context in scope is ignored.
+ *
+ * Example:
+ *
+ * ```
+ * launch(loggingContext(mapOf("kotlin" to "rocks"))) {
+ *     logger.info { "..." }   // The Thread context contains the mapping here
+ * }
+ * ```
+ */
+fun loggingContext(
+  map: Map<String, String>? = null,
+  stack: Collection<String>? = null,
+): CoroutineThreadContext = CoroutineThreadContext(ThreadContextData(map = map, stack = stack))
+
+/**
+ * Convenience function to obtain a [CoroutineThreadContext] that inherits the current context (if any), plus adds
+ * the context from the given map and stack, which default to nothing.
+ *
+ * Example:
+ *
+ * ```
+ * launch(additionalLoggingContext(mapOf("kotlin" to "rocks"))) {
+ *     logger.info { "..." }   // The Thread context contains the mapping plus whatever context was in scope at launch
+ * }
+ * ```
+ */
+fun additionalLoggingContext(
+  map: Map<String, String>? = null,
+  stack: Collection<String>? = null,
+): CoroutineThreadContext = CoroutineThreadContext(ThreadContextData() + ThreadContextData(map = map, stack = stack))
+
+/**
+ * Run the given block with the provided logging context, which default to no context. Any existing logging context
+ * in scope is ignored.
+ *
+ * Example:
+ *
+ * ```
+ * withLoggingContext(mapOf("kotlin" to "rocks")) {
+ *     logger.info { "..." }   // The Thread context contains the mapping
+ * }
+ * ```
+ */
+suspend fun <R> withLoggingContext(
+  map: Map<String, String>? = null,
+  stack: Collection<String>? = null,
+  block: suspend CoroutineScope.() -> R,
+): R = withContext(loggingContext(map, stack), block)
+
+/**
+ * Run the given block with the provided additional logging context. The given context is added to any existing
+ * logging context in scope.
+ *
+ * Example:
+ *
+ * ```
+ * withAdditionalLoggingContext(mapOf("kotlin" to "rocks")) {
+ *     logger.info { "..." }   // The Thread context contains the mapping plus whatever context was in the scope previously
+ * }
+ * ```
+ */
+suspend fun <R> withAdditionalLoggingContext(
+  map: Map<String, String>? = null,
+  stack: Collection<String>? = null,
+  block: suspend CoroutineScope.() -> R,
+): R = withContext(additionalLoggingContext(map, stack), block)

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
   <properties>
 
     <!-- project version -->
-    <revision>1.4.1-SNAPSHOT</revision>
+    <revision>1.5.0-SNAPSHOT</revision>
 
     <!-- `project.build.outputTimestamp` is required to be present for reproducible builds.
          We actually inherit one from the `org.apache:apache` through our parent `org.apache.logging:logging-parent`.

--- a/src/changelog/.1.x.x/add-coroutine-context-convenience-functions.xml
+++ b/src/changelog/.1.x.x/add-coroutine-context-convenience-functions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to you under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.2.xsd"
+       type="added">
+  <description format="asciidoc">Add convenience functions for managing logging context in coroutines</description>
+</entry>

--- a/src/site/index.adoc
+++ b/src/site/index.adoc
@@ -138,6 +138,43 @@ assert(message == ContextStack.pop())
 assert(ContextStack.empty)
 ----
 
+A `CoroutineThreadContext` context element is provided to integrate logging context with coroutines.
+
+We provide convenience functions `loggingContext` and `additionalLoggingContext` to create instances of `CoroutineThreadContext` with the appropriate context data.
+The result of these functions can be passed directly to coroutine builders to set the context for the coroutine.
+
+To set the context, ignoring any context currently in scope:
+
+[source,kotlin]
+----
+launch(loggingContext(mapOf("myKey" to "myValue"), listOf("test"))) {
+  assertEquals("myValue", ContextMap["myKey"])
+  assertEquals("test", ContextStack.peek())
+}
+----
+
+Or to preserve the existing context and add additional logging context:
+
+[source,kotlin]
+----
+launch(additionalLoggingContext(mapOf("myKey" to "myValue"), listOf("test"))) {
+  assertEquals("myValue", ContextMap["myKey"])
+  assertEquals("test", ContextStack.peek())
+}
+----
+
+Alternatively, to change the context without launching a new coroutine, the `withLoggingContext` and `withAdditionalLoggingContext` functions are provided:
+
+[source,kotlin]
+----
+withAdditionalLoggingContext(mapOf("myKey" to "myValue"), listOf("test")) {
+  assertEquals("myValue", ContextMap["myKey"])
+  assertEquals("test", ContextStack.peek())
+}
+----
+
+These functions are shorthand for `withContext(loggingContext(...))` or `withContext(additionalLoggingContext(...))`.
+
 [#params]
 == Parameter substitution
 


### PR DESCRIPTION
We were already able to create logging context for coroutines, but it was more verbose than it should be (https://github.com/apache/logging-log4j-kotlin/issues/64). Create some convenience functions to make it easy to set (or add to) the logging context for a coroutine.

Resolves https://github.com/apache/logging-log4j-kotlin/issues/64.