### PR TITLE
Handle context stack push parameters

### DIFF
--- a/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/ContextStack.kt
+++ b/log4j-api-kotlin/src/main/kotlin/org/apache/logging/log4j/kotlin/ContextStack.kt
@@ -103,7 +103,7 @@ object ContextStack {
    *
    * @see ThreadContext.push
    */
-  fun push(message: String, vararg args: Any?) = ThreadContext.push(message, args)
+  fun push(message: String, vararg args: Any?) = ThreadContext.push(message, *args)
 
   /**
    * Trims the current context stack to at most the given depth.

--- a/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/ContextStackPushTest.kt
+++ b/log4j-api-kotlin/src/test/kotlin/org.apache.logging.log4j.kotlin/ContextStackPushTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.kotlin
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ContextStackPushTest {
+  @AfterEach
+  fun tearDown() {
+    ContextStack.clear()
+  }
+
+  @Test
+  fun `Single parameter push keeps value format`() {
+    ContextStack.push("user={}", "admin")
+    assertEquals("user=admin", ContextStack.peek())
+  }
+
+  @Test
+  fun `Parameterized push keeps second parameter`() {
+    ContextStack.push("user={} action={}", "admin", "login")
+    assertEquals("user=admin action=login", ContextStack.peek())
+  }
+
+  @Test
+  fun `Parameterized push keeps third parameter`() {
+    ContextStack.push("a={} b={} c={}", "1", "2", "3")
+    assertEquals("a=1 b=2 c=3", ContextStack.peek())
+  }
+}

--- a/src/changelog/.1.x.x/context_stack_wrapper_push_fix.xml
+++ b/src/changelog/.1.x.x/context_stack_wrapper_push_fix.xml
@@ -3,6 +3,7 @@
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
        type="fixed">
+  <issue id="145" link="https://github.com/apache/logging-log4j-kotlin/issues/145"/>
   <issue id="146" link="https://github.com/apache/logging-log4j-kotlin/issues/146"/>
   <issue id="151" link="https://github.com/apache/logging-log4j-kotlin/pull/151"/>
   <description format="asciidoc">Context stack push parameters are handled correctly</description>

--- a/src/changelog/.1.x.x/context_stack_wrapper_push_fix.xml
+++ b/src/changelog/.1.x.x/context_stack_wrapper_push_fix.xml
@@ -2,7 +2,8 @@
 <entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="https://logging.apache.org/xml/ns"
        xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
-       type="updated">
+       type="fixed">
   <issue id="146" link="https://github.com/apache/logging-log4j-kotlin/issues/146"/>
+  <issue id="151" link="https://github.com/apache/logging-log4j-kotlin/pull/151"/>
   <description format="asciidoc">Context stack push parameters are handled correctly</description>
 </entry>

--- a/src/changelog/.1.x.x/context_stack_wrapper_push_fix.xml
+++ b/src/changelog/.1.x.x/context_stack_wrapper_push_fix.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="https://logging.apache.org/xml/ns"
+       xsi:schemaLocation="https://logging.apache.org/xml/ns https://logging.apache.org/xml/ns/log4j-changelog-0.xsd"
+       type="updated">
+  <issue id="146" link="https://github.com/apache/logging-log4j-kotlin/issues/146"/>
+  <description format="asciidoc">Context stack push parameters are handled correctly</description>
+</entry>


### PR DESCRIPTION
Context stack push now spreads the `args` argument properly.

Add tests created by @cookiejack15 in #146.

Resolves #145 and #146.

Review requested from one of @vy or @jvz 